### PR TITLE
Update plugin.xml to remove config entry that causes duplicate resource error.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="com.intel.googleplaygamesplugin"
-    version="1.0.5">
+    version="1.0.6">
 
     <name>GooglePlayGamesPlugin</name>
 
@@ -47,7 +47,6 @@
 
         <config-file target="res/values/strings.xml" parent="/*">
              <string name="google_play_services_app_id">$GPSAPPID</string>
-             <integer name="google_play_services_version">6171000</integer>
         </config-file>
 
         <source-file src="src/android/gamehelper_strings.xml" target-dir="res/values" />


### PR DESCRIPTION
When I add this plugin and build with cordova-android 4.1.0, I get the following error:
`
:mergeReleaseResources
.../cordova_1235132/platforms/android/res/values/version.xml: Error: Duplicate resources: .../cordova_1235132/platforms/android/res/values/version.xml:integer/google_play_services_version, .../cordova_1235132/platforms/android/res/values/strings.xml:integer/google_play_services_version
:mergeReleaseResources FAILED
`

This is because the string resource google_play_services_version is defined in this plugin and also [in the com.google.playservices plugin dependency](https://github.com/MobileChromeApps/google-play-services/blob/1f56399572d255193f8f9564843df60e50938e69/plugin.xml#L21).

The commit for this PR removes the resource from this plugin and bumps the version.
